### PR TITLE
remove b-tax packages

### DIFF
--- a/import_packages.py
+++ b/import_packages.py
@@ -1,8 +1,6 @@
 # This file imports all necessary packages
 import taxcalc
 from taxcalc import *
-import btax
-from btax.run_btax import run_btax, run_btax_with_baseline_delta
 import pandas as pd
 import numpy as np
 import copy


### PR DESCRIPTION
This PR simply removes the B-Tax packages from `import_pacakges.py` now that @codykallen has removed the B-Tax dependencies.